### PR TITLE
Add 39 failing bitwise test scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ For scripts with multiple parameter combinations (e.g., failing tests):
 ```haskell
 -- PlutusScripts/Bitwise/ReadBit.hs (Common module)
 data Params = Params { s :: BuiltinByteString, i :: Integer, output :: Bool }
-failingReadBitParams :: [Params]  -- 14 test cases
+failingReadBitParams :: [Params]  -- Test cases for edge conditions
 
 -- PlutusScripts/Bitwise/V_1_1.hs
 failingBitwiseScriptGroupsV3 :: [ScriptGroup DefaultUni DefaultFun (BuiltinData -> BuiltinUnit)]
@@ -239,15 +239,15 @@ The `envelopes` executable serializes all scripts to `.plutus` files:
 cabal run envelopes
 ```
 
-Output: **59 `.plutus` files** in `serialised-plutus-scripts/` (git-ignored)
+Output: Multiple `.plutus` files in `serialised-plutus-scripts/` (git-ignored)
 
 **Generated Scripts**:
-- 1 PlutusV2 script (bytestring/integer conversions)
-- 5 Basic PlutusV3 scripts (always succeed/fail, token names, time ranges, redeemers)
-- 2 SECP256k1 scripts (Schnorr, ECDSA signature verification)
-- 1 Hashing script (RIPEMD-160)
-- 11 Bitwise succeeding tests (AND, OR, XOR, complement, shift, rotate, bit operations)
-- 39 Bitwise failing tests (14 ReadBit + 19 WriteBits + 6 ReplicateByte edge cases)
+- PlutusV2 scripts (bytestring/integer conversions)
+- Basic PlutusV3 scripts (always succeed/fail, token names, time ranges, redeemers)
+- SECP256k1 scripts (Schnorr and ECDSA signature verification)
+- Hashing scripts (RIPEMD-160)
+- Bitwise succeeding tests (AND, OR, XOR, complement, shift, rotate, bit operations)
+- Bitwise failing tests (ReadBit, WriteBits, ReplicateByte edge case validation)
 
 These serialized scripts are consumed by external E2E tests (e.g., `cardano-node-tests`).
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ cabal run envelopes
 
 The generated `.plutus` files are JSON envelopes containing the serialized Plutus scripts, ready for use in cardano-node-tests.
 
-**Generated Scripts (59 total)**:
-- 1 PlutusV2 script
-- 5 Basic PlutusV3 scripts
-- 2 SECP256k1 scripts
-- 1 Hashing script
-- 11 Bitwise succeeding tests
-- 39 Bitwise failing tests (14 ReadBit + 19 WriteBits + 6 ReplicateByte)
+**Generated Scripts**:
+- PlutusV2 scripts (bytestring/integer conversions)
+- Basic PlutusV3 scripts (always succeed/fail, token names, time ranges, redeemers)
+- SECP256k1 scripts (Schnorr and ECDSA signature verification)
+- Hashing scripts (RIPEMD-160)
+- Bitwise succeeding tests (AND, OR, XOR, complement, shift, rotate, bit operations)
+- Bitwise failing tests (ReadBit, WriteBits, ReplicateByte edge case variants)
 
 ## Project Structure
 
@@ -86,16 +86,16 @@ Core testing scripts for fundamental blockchain operations:
 
 Scripts demonstrating Plutus bitwise primitives (Plutus Core 1.1.0+):
 
-**Succeeding Tests (11 scripts)**:
+**Succeeding Tests**:
 - Logical operations: `andByteString`, `orByteString`, `xorByteString`, `complementByteString`
 - Shifts and rotates: `shiftByteString`, `rotateByteString`
 - Bit manipulation: `readBit`, `writeBits`, `countSetBits`, `findFirstSetBit`
 - Byte operations: `replicateByte`, conversions between integers and bytestrings
 
-**Failing Tests (39 scripts)**:
-- ReadBit edge cases: empty bytestring, negative indices, out of bounds, Int64 limits (14 variants)
-- WriteBits edge cases: empty bytestring, negative indices, out of bounds (19 variants)
-- ReplicateByte edge cases: negative count, invalid byte values, size limits (6 variants)
+**Failing Tests**:
+- ReadBit edge cases: empty bytestring, negative indices, out of bounds, Int64 limits
+- WriteBits edge cases: empty bytestring, negative indices, out of bounds
+- ReplicateByte edge cases: negative count, invalid byte values, size limits
 
 These failing tests validate proper error handling for invalid inputs adapted from `plutus-conformance` tests.
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,18 @@ cabal build plutus-scripts
 # Generate serialized script envelopes
 cabal run envelopes
 
-# Output: plutus-scripts/serialised-plutus-scripts/*.plutus
+# Output: serialised-plutus-scripts/*.plutus (59 scripts total)
 ```
 
 The generated `.plutus` files are JSON envelopes containing the serialized Plutus scripts, ready for use in cardano-node-tests.
+
+**Generated Scripts (59 total)**:
+- 1 PlutusV2 script
+- 5 Basic PlutusV3 scripts
+- 2 SECP256k1 scripts
+- 1 Hashing script
+- 11 Bitwise succeeding tests
+- 39 Bitwise failing tests (14 ReadBit + 19 WriteBits + 6 ReplicateByte)
 
 ## Project Structure
 
@@ -78,10 +86,18 @@ Core testing scripts for fundamental blockchain operations:
 
 Scripts demonstrating Plutus bitwise primitives (Plutus Core 1.1.0+):
 
+**Succeeding Tests (11 scripts)**:
 - Logical operations: `andByteString`, `orByteString`, `xorByteString`, `complementByteString`
 - Shifts and rotates: `shiftByteString`, `rotateByteString`
 - Bit manipulation: `readBit`, `writeBits`, `countSetBits`, `findFirstSetBit`
 - Byte operations: `replicateByte`, conversions between integers and bytestrings
+
+**Failing Tests (39 scripts)**:
+- ReadBit edge cases: empty bytestring, negative indices, out of bounds, Int64 limits (14 variants)
+- WriteBits edge cases: empty bytestring, negative indices, out of bounds (19 variants)
+- ReplicateByte edge cases: negative count, invalid byte values, size limits (6 variants)
+
+These failing tests validate proper error handling for invalid inputs adapted from `plutus-conformance` tests.
 
 ### Cryptographic Scripts
 

--- a/plutus-scripts/Helpers/ScriptUtils.hs
+++ b/plutus-scripts/Helpers/ScriptUtils.hs
@@ -1,5 +1,16 @@
 -- subset of utilities from plutus-script-utils
-module Helpers.ScriptUtils where
+module Helpers.ScriptUtils (
+  IsScriptContext (..),
+  UntypedValidator,
+  UntypedMintingPolicy,
+  UntypedStakeValidator,
+  ScriptGroup (..),
+  ScriptContextV1,
+  ScriptContextV2,
+  ScriptContextV3,
+  check,
+  constrArgs,
+) where
 
 import PlutusLedgerApi.V1 qualified as V1
 import PlutusLedgerApi.V2 qualified as V2
@@ -10,11 +21,27 @@ import PlutusTx.Builtins.Internal qualified as BI (
   snd,
   unsafeDataAsConstr,
  )
+import PlutusTx.Code (CompiledCodeIn)
 import PlutusTx.Prelude qualified as P
 
 type UntypedValidator = V1.BuiltinData -> V1.BuiltinData -> V1.BuiltinData -> ()
 type UntypedMintingPolicy = V1.BuiltinData -> V1.BuiltinData -> ()
 type UntypedStakeValidator = V1.BuiltinData -> V1.BuiltinData -> ()
+
+{- | Group of related scripts with a common base name for numbered output.
+
+Useful for test variants where multiple parameter combinations generate
+numbered scripts (e.g., failingReadBit_1.plutus, failingReadBit_2.plutus).
+
+The executable can iterate over 'sgScripts' and generate files named
+@sgBaseName ++ "_" ++ show n ++ ".plutus"@.
+-}
+data ScriptGroup uni fun a = ScriptGroup
+  { sgBaseName :: String
+    -- ^ Base name for the script group (e.g., "failingReadBitPolicyScriptV3")
+  , sgScripts :: [CompiledCodeIn uni fun a]
+    -- ^ List of compiled scripts, will be numbered from 1
+  }
 
 {-# INLINEABLE tracedUnsafeFrom #-}
 tracedUnsafeFrom :: forall a. (UnsafeFromData a) => P.BuiltinString -> V1.BuiltinData -> a

--- a/plutus-scripts/PlutusScripts/Bitwise/V_1_1.hs
+++ b/plutus-scripts/PlutusScripts/Bitwise/V_1_1.hs
@@ -159,17 +159,17 @@ succeedingReplicateBytePolicyCompiledV3 =
 -- Each group generates numbered scripts (e.g., failingReadBit_1.plutus, failingReadBit_2.plutus)
 failingBitwiseScriptGroupsV3 :: [ScriptGroup DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)]
 failingBitwiseScriptGroupsV3 =
-  [ -- ReadBit failing tests (14 variants)
+  [ -- ReadBit failing tests
     ScriptGroup
       { sgBaseName = "failingReadBitPolicyScriptV3"
       , sgScripts = map compileReadBit failingReadBitParams
       }
-  , -- WriteBits failing tests (19 variants)
+  , -- WriteBits failing tests
     ScriptGroup
       { sgBaseName = "failingWriteBitsPolicyScriptV3"
       , sgScripts = map compileWriteBits failingWriteBitsParams
       }
-  , -- ReplicateByte failing tests (6 variants)
+  , -- ReplicateByte failing tests
     ScriptGroup
       { sgBaseName = "failingReplicateBytePolicyScriptV3"
       , sgScripts = map compileReplicateByte failingReplicateByteParams

--- a/plutus-scripts/PlutusScripts/Bitwise/V_1_1.hs
+++ b/plutus-scripts/PlutusScripts/Bitwise/V_1_1.hs
@@ -2,7 +2,7 @@
 
 module PlutusScripts.Bitwise.V_1_1 where
 
-import Helpers.ScriptUtils (IsScriptContext (mkUntypedMintingPolicy))
+import Helpers.ScriptUtils (IsScriptContext (mkUntypedMintingPolicy), ScriptGroup (ScriptGroup, sgBaseName, sgScripts))
 import PlutusCore.Default (DefaultFun, DefaultUni)
 import PlutusCore.Version (plcVersion110)
 import PlutusLedgerApi.V3 qualified as V3
@@ -30,10 +30,12 @@ import PlutusScripts.Bitwise.Logical (
   succeedingXorByteStringParams,
  )
 import PlutusScripts.Bitwise.ReadBit (
+  failingReadBitParams,
   mkReadBitPolicy,
   succeedingReadBitParams,
  )
 import PlutusScripts.Bitwise.ReplicateByte (
+  failingReplicateByteParams,
   mkReplicateBytePolicy,
   succeedingReplicateByteParams,
  )
@@ -44,6 +46,7 @@ import PlutusScripts.Bitwise.ShiftRotate (
   succeedingShiftByteStringParams,
  )
 import PlutusScripts.Bitwise.WriteBits (
+  failingWriteBitsParams,
   mkWriteBitsPolicy,
   succeedingWriteBitsParams,
  )
@@ -149,6 +152,38 @@ succeedingReplicateBytePolicyCompiledV3 =
   $$(compile [||mkReplicateBytePolicy||])
     `unsafeApplyCode` liftCode plcVersion110 succeedingReplicateByteParams
 
--- Note: Failing test scripts are not currently generated.
--- They require applying individual failing params which would need the Params types to be exported.
--- For now, only succeeding tests are supported.
+--------------------------------------------------------------------------------
+-- Failing Tests ---------------------------------------------------------------
+
+-- | All failing bitwise test script groups
+-- Each group generates numbered scripts (e.g., failingReadBit_1.plutus, failingReadBit_2.plutus)
+failingBitwiseScriptGroupsV3 :: [ScriptGroup DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)]
+failingBitwiseScriptGroupsV3 =
+  [ -- ReadBit failing tests (14 variants)
+    ScriptGroup
+      { sgBaseName = "failingReadBitPolicyScriptV3"
+      , sgScripts = map compileReadBit failingReadBitParams
+      }
+  , -- WriteBits failing tests (19 variants)
+    ScriptGroup
+      { sgBaseName = "failingWriteBitsPolicyScriptV3"
+      , sgScripts = map compileWriteBits failingWriteBitsParams
+      }
+  , -- ReplicateByte failing tests (6 variants)
+    ScriptGroup
+      { sgBaseName = "failingReplicateBytePolicyScriptV3"
+      , sgScripts = map compileReplicateByte failingReplicateByteParams
+      }
+  ]
+ where
+  compileReadBit param =
+    $$(compile [||mkReadBitPolicy||])
+      `unsafeApplyCode` liftCode plcVersion110 [param]
+
+  compileWriteBits param =
+    $$(compile [||mkWriteBitsPolicy||])
+      `unsafeApplyCode` liftCode plcVersion110 [param]
+
+  compileReplicateByte param =
+    $$(compile [||mkReplicateBytePolicy||])
+      `unsafeApplyCode` liftCode plcVersion110 [param]

--- a/plutus-scripts/app/Main.hs
+++ b/plutus-scripts/app/Main.hs
@@ -84,7 +84,7 @@ main = withUtf8 do
     "succeedingReplicateBytePolicyScriptV3"
     BitwiseV1.succeedingReplicateBytePolicyCompiledV3
 
-  -- Failing Bitwise Tests (39 scripts: 14 ReadBit + 19 WriteBits + 6 ReplicateByte)
+  -- Failing Bitwise Tests (ReadBit, WriteBits, ReplicateByte variants)
   mapM_ writeScriptGroup BitwiseV1.failingBitwiseScriptGroupsV3
 
 --------------------------------------------------------------------------------

--- a/plutus-scripts/plutus-scripts.cabal
+++ b/plutus-scripts/plutus-scripts.cabal
@@ -126,6 +126,7 @@ executable envelopes
   build-depends:
     , base               >=4.14      && <5
     , directory
+    , plutus-core        ^>=1.53.1.0
     , plutus-ledger-api  ^>=1.53.1.0
     , plutus-tx          ^>=1.53.1.0
     , scripts


### PR DESCRIPTION
## Summary

Implements generation of 39 failing bitwise test scripts to restore complete test coverage for Plutus Core 1.1.0 bitwise primitives. This addresses the gap created during the November 2025 library/executable separation refactoring.

**Impact**: Increases generated scripts from 20 to 59 (restores 1:1 correspondence with cardano-node-tests for bitwise tests)

## Changes

### ScriptGroup Infrastructure

Introduced a generic `ScriptGroup` type in `Helpers/ScriptUtils.hs`:
- Organizes parameterized test variants with clean separation of concerns
- Library handles parameter iteration, executable generates numbered files
- Reusable pattern for any multi-variant test scenarios

### Failing Test Coverage (39 new scripts)

**ReadBit Tests** (`failingReadBitPolicyScriptV3_1` through `_14`):
- Empty bytestring edge cases
- Negative index validation
- Out of bounds access
- Int64 min/max boundary conditions

**WriteBits Tests** (`failingWriteBitsPolicyScriptV3_1` through `_19`):
- Empty bytestring edge cases
- Negative indices in bit position lists
- Out of bounds bit positions
- Large indices beyond Int64 range

**ReplicateByte Tests** (`failingReplicateBytePolicyScriptV3_1` through `_6`):
- Negative count validation
- Invalid byte values (< 0, > 255)
- Size limit violations (exceeding 8192 byte maximum)

### Architecture Maintained

✅ **Library stays pure**: Only exports `CompiledCode` values, no IO operations
✅ **Params encapsulation**: Iteration via `map` in library, executable unaware of Params types
✅ **Clean separation**: Library compiles, executable writes files
✅ **Type safety**: ScriptGroup ensures base name and scripts stay together

### Files Modified

- `Helpers/ScriptUtils.hs`: Added ScriptGroup type definition
- `PlutusScripts/Bitwise/V_1_1.hs`: Created failingBitwiseScriptGroupsV3 export
- `app/Main.hs`: Added writeScriptGroup helper and generation call
- `plutus-scripts.cabal`: Added plutus-core dependency to executable
- `README.md`: Updated script counts and failing test descriptions
- `CLAUDE.md`: Documented ScriptGroup pattern with examples

## Testing

Build verification:
```bash
cabal build plutus-scripts --ghc-options=-Werror  # ✅ Passes
cabal run envelopes  # ✅ Generates 59 scripts
```

Output verification:
- Total scripts: 59 (previously 20)
- Failing ReadBit: 14 scripts
- Failing WriteBits: 19 scripts
- Failing ReplicateByte: 6 scripts
- All naming matches cardano-node-tests format

## Verification Against cardano-node-tests

**File Presence**: ✅ All 39 failing test scripts present with correct naming
**CBOR Comparison**: Different encodings (expected - compiled with Plutus 1.53 vs 1.36 reference)
**File Sizes**: Comparable, often smaller (suggests compiler improvements)

## Notes

### CBOR Differences

All scripts have different CBOR encodings compared to cardano-node-tests reference scripts. This is **expected and acceptable** because:
- Reference scripts compiled with Plutus 1.36 (October 2024)
- Our scripts compiled with Plutus 1.53 (November 2025)
- Different compiler versions produce functionally equivalent but differently encoded bytecode
- Our scripts are generally smaller (better optimization)

Functional equivalence should be validated by running cardano-node-tests with our generated scripts.

### Out of Scope

The following scripts exist in cardano-node-tests but are not added in this PR:
- `blsMint.plutus`
- `blsSpend.plutus`
- `constitutionScriptV3.plutus`

Git history shows these were **never generated by this repository** (BLS and Governance modules exist as library code only). Awaiting clarification on whether to add them.

## Related

Closes investigation into missing failing test scripts documented in commit history.