### PR TITLE
Fix uses of CompiledCode in `dropList` tests and elsewhere.

### DIFF
--- a/plutus-scripts/PlutusScripts/Batch6/DropList/V3_100.hs
+++ b/plutus-scripts/PlutusScripts/Batch6/DropList/V3_100.hs
@@ -7,12 +7,12 @@ import PlutusCore.Default (DefaultFun, DefaultUni)
 import PlutusCore.Version (plcVersion100)
 import PlutusScripts.Batch6.DropList.Common qualified as DropList
 import PlutusTx (compile, liftCode, unsafeApplyCode)
-import PlutusTx.Code (CompiledCodeIn)
+import PlutusTx.Code (CompiledCode)
 import PlutusTx.Prelude qualified as P
 
 -- Compiled code values with parameters already applied for succeeding tests
 succeedingDropListPolicy
-  :: CompiledCodeIn DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)
+  :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingDropListPolicy =
   $$(compile [||DropList.mkDropListPolicy||])
     `unsafeApplyCode` liftCode plcVersion100 DropList.succeedingDropListParams

--- a/plutus-scripts/PlutusScripts/Batch6/DropList/V3_110.hs
+++ b/plutus-scripts/PlutusScripts/Batch6/DropList/V3_110.hs
@@ -7,11 +7,12 @@ import PlutusCore.Default (DefaultFun, DefaultUni)
 import PlutusCore.Version (plcVersion110)
 import PlutusScripts.Batch6.DropList.Common qualified as DropList
 import PlutusTx (compile, liftCode, unsafeApplyCode)
-import PlutusTx.Code (CompiledCodeIn)
+import PlutusTx.Code (CompiledCode)
 import PlutusTx.Prelude qualified as P
 
 -- Compiled code values with parameters already applied for succeeding tests
-succeedingDropListPolicy :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
+succeedingDropListPolicy
+  :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingDropListPolicy =
   $$(compile [||DropList.mkDropListPolicy||])
     `unsafeApplyCode` liftCode plcVersion110 DropList.succeedingDropListParams

--- a/plutus-scripts/PlutusScripts/Bitwise/V_1_1.hs
+++ b/plutus-scripts/PlutusScripts/Bitwise/V_1_1.hs
@@ -54,7 +54,7 @@ import PlutusScripts.Bitwise.WriteBits (
   succeedingWriteBitsParams,
  )
 import PlutusTx (compile, liftCode, unsafeApplyCode)
-import PlutusTx.Code (CompiledCodeIn)
+import PlutusTx.Code (CompiledCode)
 import PlutusTx.Prelude qualified as P
 
 -- ByteString to Integer --
@@ -90,67 +90,67 @@ byteStringToIntegerRoundtripPolicyV3 =
 
 -- Compiled code values with parameters already applied for succeeding tests
 succeedingAndByteStringPolicyCompiledV3
-  :: CompiledCodeIn DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)
+  :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingAndByteStringPolicyCompiledV3 =
   $$(compile [||mkAndByteStringPolicy||])
     `unsafeApplyCode` liftCode plcVersion110 succeedingAndByteStringParams
 
 succeedingOrByteStringPolicyCompiledV3
-  :: CompiledCodeIn DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)
+  :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingOrByteStringPolicyCompiledV3 =
   $$(compile [||mkOrByteStringPolicy||])
     `unsafeApplyCode` liftCode plcVersion110 succeedingOrByteStringParams
 
 succeedingXorByteStringPolicyCompiledV3
-  :: CompiledCodeIn DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)
+  :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingXorByteStringPolicyCompiledV3 =
   $$(compile [||mkXorByteStringPolicy||])
     `unsafeApplyCode` liftCode plcVersion110 succeedingXorByteStringParams
 
 succeedingComplementByteStringPolicyCompiledV3
-  :: CompiledCodeIn DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)
+  :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingComplementByteStringPolicyCompiledV3 =
   $$(compile [||mkComplementByteStringPolicy||])
     `unsafeApplyCode` liftCode plcVersion110 succeedingComplementByteStringParams
 
 succeedingShiftByteStringPolicyCompiledV3
-  :: CompiledCodeIn DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)
+  :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingShiftByteStringPolicyCompiledV3 =
   $$(compile [||mkShiftByteStringPolicy||])
     `unsafeApplyCode` liftCode plcVersion110 succeedingShiftByteStringParams
 
 succeedingRotateByteStringPolicyCompiledV3
-  :: CompiledCodeIn DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)
+  :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingRotateByteStringPolicyCompiledV3 =
   $$(compile [||mkRotateByteStringPolicy||])
     `unsafeApplyCode` liftCode plcVersion110 succeedingRotateByteStringParams
 
 succeedingCountSetBitsPolicyCompiledV3
-  :: CompiledCodeIn DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)
+  :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingCountSetBitsPolicyCompiledV3 =
   $$(compile [||mkCountSetBitsPolicy||])
     `unsafeApplyCode` liftCode plcVersion110 succeedingCountSetBitsParams
 
 succeedingFindFirstSetBitPolicyCompiledV3
-  :: CompiledCodeIn DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)
+  :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingFindFirstSetBitPolicyCompiledV3 =
   $$(compile [||mkFindFirstSetBitPolicy||])
     `unsafeApplyCode` liftCode plcVersion110 succeedingFindFirstSetBitParams
 
 succeedingReadBitPolicyCompiledV3
-  :: CompiledCodeIn DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)
+  :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingReadBitPolicyCompiledV3 =
   $$(compile [||mkReadBitPolicy||])
     `unsafeApplyCode` liftCode plcVersion110 succeedingReadBitParams
 
 succeedingWriteBitsPolicyCompiledV3
-  :: CompiledCodeIn DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)
+  :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingWriteBitsPolicyCompiledV3 =
   $$(compile [||mkWriteBitsPolicy||])
     `unsafeApplyCode` liftCode plcVersion110 succeedingWriteBitsParams
 
 succeedingReplicateBytePolicyCompiledV3
-  :: CompiledCodeIn DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)
+  :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingReplicateBytePolicyCompiledV3 =
   $$(compile [||mkReplicateBytePolicy||])
     `unsafeApplyCode` liftCode plcVersion110 succeedingReplicateByteParams

--- a/plutus-scripts/PlutusScripts/Hashing/V_1_1.hs
+++ b/plutus-scripts/PlutusScripts/Hashing/V_1_1.hs
@@ -2,13 +2,12 @@
 
 module PlutusScripts.Hashing.V_1_1 where
 
-import PlutusCore.Default (DefaultFun, DefaultUni)
 import PlutusCore.Version (plcVersion110)
 import PlutusLedgerApi.V3 qualified as V3
 import PlutusScripts.Hashing.Common (hashingParamsV3, mkHashingPolicyV3)
 import PlutusScripts.Hashing.Ripemd_160 (mkRipemd_160Policy, succeedingRipemd_160Params)
 import PlutusTx (compile, liftCode, unsafeApplyCode)
-import PlutusTx.Code (CompiledCodeIn)
+import PlutusTx.Code (CompiledCode)
 import PlutusTx.Prelude qualified as P
 
 checkHashingPolicy :: V3.SerialisedScript
@@ -20,7 +19,7 @@ checkHashingPolicy =
 -- A separate test for ripemd_160 since that only appeared in PlutusV3
 
 succeedingRipemd_160PolicyCompiled
-  :: CompiledCodeIn DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)
+  :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingRipemd_160PolicyCompiled =
   $$(compile [||mkRipemd_160Policy||])
     `unsafeApplyCode` liftCode plcVersion110 succeedingRipemd_160Params


### PR DESCRIPTION
We switched from `CompiledCodeIn` to `CompiledCode` in #18, but I changed the `dropList` tests in only one place when I should have changed in several places, which meant that it didn't build.  This fixes that.

Edit: I found a few more uses of `CompiledCodeIn` and got rid of thsoe too.