### PR TITLE
chore(deps): update plutus packages to 1.55.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,7 +12,7 @@ repository cardano-haskell-packages
 
 index-state:
   , hackage.haskell.org 2025-11-11T08:00:56Z
-  , cardano-haskell-packages 2025-11-07T15:42:47Z
+  , cardano-haskell-packages 2025-11-26T15:49:48Z
 packages: plutus-scripts
 
 write-ghc-environment-files: always

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1762532039,
-        "narHash": "sha256-TggDBiYZcwNEj5YaynLzGVQQJmIpdqtw01N/L9g78tw=",
+        "lastModified": 1764278124,
+        "narHash": "sha256-6UkDg5Zl6MqDhe2bn+6TdjQTL+G2HTiUyRmw1OAYzrM=",
         "owner": "IntersectMBO",
         "repo": "cardano-haskell-packages",
-        "rev": "d80374d1cbefbd86e48b0230ffc5d4b253f257d1",
+        "rev": "05ed6c1e6454b756397035f6b4c7431fe4346fbc",
         "type": "github"
       },
       "original": {

--- a/plutus-scripts/plutus-scripts.cabal
+++ b/plutus-scripts/plutus-scripts.cabal
@@ -68,10 +68,10 @@ library scripts
   build-depends:
     , base               >=4.14      && <5
     , bytestring
-    , plutus-core        ^>=1.53.1.0
-    , plutus-ledger-api  ^>=1.53.1.0
-    , plutus-tx          ^>=1.53.1.0
-    , plutus-tx-plugin   ^>=1.53.1.0
+    , plutus-core        ^>=1.55.0.0
+    , plutus-ledger-api  ^>=1.55.0.0
+    , plutus-tx          ^>=1.55.0.0
+    , plutus-tx-plugin   ^>=1.55.0.0
     , text
 
   exposed-modules:
@@ -144,9 +144,9 @@ executable envelopes
   build-depends:
     , base               >=4.14      && <5
     , directory
-    , plutus-core        ^>=1.53.1.0
-    , plutus-ledger-api  ^>=1.53.1.0
-    , plutus-tx          ^>=1.53.1.0
+    , plutus-core        ^>=1.55.0.0
+    , plutus-ledger-api  ^>=1.55.0.0
+    , plutus-tx          ^>=1.55.0.0
     , scripts
     , text
     , with-utf8


### PR DESCRIPTION
Bump CHaP index-state to 2025-11-26 and update all plutus dependencies from 1.53.1.0 to 1.55.0.0. This brings in the latest Plutus toolchain improvements.