### PR TITLE
chore(deps): update hackage index-state to 2025-11-28

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,7 +11,7 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 index-state:
-  , hackage.haskell.org 2025-11-11T08:00:56Z
+  , hackage.haskell.org 2025-11-28T09:11:45Z
   , cardano-haskell-packages 2025-11-26T15:49:48Z
 packages: plutus-scripts
 

--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1762856356,
-        "narHash": "sha256-2ZOuaSJE5QHnNJ9CGQ7GvSJWMjcvBnMRZdGNQ8xm/f4=",
+        "lastModified": 1764321834,
+        "narHash": "sha256-ryYQ9Xu5xDcr7BBxREpeoTY9ESOespBkNSUNTAuzPxk=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "7f2ccefcd6263415158a832bdd062a69298cc970",
+        "rev": "df8b8a32ed1971c7442fc05e8bd086a3af9d91eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Context

- **What**: Update hackage.haskell.org index-state to latest
- **Why**: Keep dependencies current after plutus 1.55.0.0 upgrade

## Changes

- Bump hackage.haskell.org index-state from 2025-11-11 to 2025-11-28
- Update flake.lock with new hackage.nix revision

## How to Test

1. Run `nix develop` to enter development shell
2. Run `cabal build plutus-scripts` to verify build succeeds