### PR TITLE
Rename test case for consistency

### DIFF
--- a/plutus-scripts/PlutusScripts/Batch6/ExpModInteger/Common.hs
+++ b/plutus-scripts/PlutusScripts/Batch6/ExpModInteger/Common.hs
@@ -10,9 +10,9 @@ module PlutusScripts.Batch6.ExpModInteger.Common (
   mkSimpleExpModIntegerPolicy,
   succeedingSimpleExpModIntegerParams,
   mkExpModIntegerInversePolicy,
-  succeedingInverseParams,
-  mkExponentOnePolicy,
-  succeedingExponentOneParams,
+  succeedingExpModIntegerInverseParams,
+  mkExpModIntegerExponentOnePolicy,
+  succeedingExpModIntegerExponentOneParams,
   failingExpModIntegerParams,
 )
 where
@@ -272,8 +272,8 @@ mkExpModIntegerInversePolicy l _ctx = go l
       else P.traceError "mkExpModIntegerInversePolicy"
 
 -- The result is always 1 here
-succeedingInverseParams :: [SimpleParams]
-succeedingInverseParams =
+succeedingExpModIntegerInverseParams :: [SimpleParams]
+succeedingExpModIntegerInverseParams =
   [ SimpleParams -- m > 1, e = -1, gcd a m = 1 -> compute inverse
       18
       (-1)
@@ -329,18 +329,18 @@ PlutusTx.unstableMakeIsData ''ExponentOneParams
 PlutusTx.makeLift ''ExponentOneParams
 
 -- m > 1, e = 1 -> return b modulo m
-{-# INLINEABLE mkExponentOnePolicy #-}
-mkExponentOnePolicy :: [ExponentOneParams] -> P.BuiltinData -> P.BuiltinUnit
-mkExponentOnePolicy l _ctx = go l
+{-# INLINEABLE mkExpModIntegerExponentOnePolicy #-}
+mkExpModIntegerExponentOnePolicy :: [ExponentOneParams] -> P.BuiltinData -> P.BuiltinUnit
+mkExpModIntegerExponentOnePolicy l _ctx = go l
  where
   go [] = BI.unitval
   go (ExponentOneParams{..} : rest) =
     if BI.expModInteger a1 1 m1 == BI.modInteger a1 m1
       then go rest
-      else P.traceError "mkExponentOnePolicy"
+      else P.traceError "mkExpModIntegerExponentOnePolicy"
 
-succeedingExponentOneParams :: [ExponentOneParams]
-succeedingExponentOneParams =
+succeedingExpModIntegerExponentOneParams :: [ExponentOneParams]
+succeedingExpModIntegerExponentOneParams =
   [ ExponentOneParams 117 1000
   , ExponentOneParams 4123213117 1000
   , ExponentOneParams (-883) 1000

--- a/plutus-scripts/PlutusScripts/Batch6/ExpModInteger/V3_100.hs
+++ b/plutus-scripts/PlutusScripts/Batch6/ExpModInteger/V3_100.hs
@@ -4,7 +4,7 @@ module PlutusScripts.Batch6.ExpModInteger.V3_100 (
   failingExpModIntegerScriptGroup,
   succeedingExpModIntegerPolicy,
   succeedingExpModIntegerInversePolicy,
-  succeedingExponentOnePolicy,
+  succeedingExpModIntegerExponentOnePolicy,
 )
 where
 
@@ -13,11 +13,11 @@ import PlutusCore.Default (DefaultFun, DefaultUni)
 import PlutusCore.Version (plcVersion100)
 import PlutusScripts.Batch6.ExpModInteger.Common (
   failingExpModIntegerParams,
+  mkExpModIntegerExponentOnePolicy,
   mkExpModIntegerInversePolicy,
-  mkExponentOnePolicy,
   mkSimpleExpModIntegerPolicy,
-  succeedingExponentOneParams,
-  succeedingInverseParams,
+  succeedingExpModIntegerExponentOneParams,
+  succeedingExpModIntegerInverseParams,
   succeedingSimpleExpModIntegerParams,
  )
 import PlutusTx (compile, liftCode, unsafeApplyCode)
@@ -33,12 +33,12 @@ succeedingExpModIntegerPolicy =
 succeedingExpModIntegerInversePolicy :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingExpModIntegerInversePolicy =
   $$(compile [||mkExpModIntegerInversePolicy||])
-    `unsafeApplyCode` liftCode plcVersion100 succeedingInverseParams
+    `unsafeApplyCode` liftCode plcVersion100 succeedingExpModIntegerInverseParams
 
-succeedingExponentOnePolicy :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
-succeedingExponentOnePolicy =
-  $$(compile [||mkExponentOnePolicy||])
-    `unsafeApplyCode` liftCode plcVersion100 succeedingExponentOneParams
+succeedingExpModIntegerExponentOnePolicy :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
+succeedingExpModIntegerExponentOnePolicy =
+  $$(compile [||mkExpModIntegerExponentOnePolicy||])
+    `unsafeApplyCode` liftCode plcVersion100 succeedingExpModIntegerExponentOneParams
 
 failingExpModIntegerScriptGroup
   :: ScriptGroup DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)

--- a/plutus-scripts/PlutusScripts/Batch6/ExpModInteger/V3_110.hs
+++ b/plutus-scripts/PlutusScripts/Batch6/ExpModInteger/V3_110.hs
@@ -4,7 +4,7 @@ module PlutusScripts.Batch6.ExpModInteger.V3_110 (
   failingExpModIntegerScriptGroup,
   succeedingExpModIntegerPolicy,
   succeedingExpModIntegerInversePolicy,
-  succeedingExponentOnePolicy,
+  succeedingExpModIntegerExponentOnePolicy,
 )
 where
 
@@ -13,11 +13,11 @@ import PlutusCore.Default (DefaultFun, DefaultUni)
 import PlutusCore.Version (plcVersion110)
 import PlutusScripts.Batch6.ExpModInteger.Common (
   failingExpModIntegerParams,
+  mkExpModIntegerExponentOnePolicy,
   mkExpModIntegerInversePolicy,
-  mkExponentOnePolicy,
   mkSimpleExpModIntegerPolicy,
-  succeedingExponentOneParams,
-  succeedingInverseParams,
+  succeedingExpModIntegerExponentOneParams,
+  succeedingExpModIntegerInverseParams,
   succeedingSimpleExpModIntegerParams,
  )
 import PlutusTx (compile, liftCode, unsafeApplyCode)
@@ -33,12 +33,12 @@ succeedingExpModIntegerPolicy =
 succeedingExpModIntegerInversePolicy :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
 succeedingExpModIntegerInversePolicy =
   $$(compile [||mkExpModIntegerInversePolicy||])
-    `unsafeApplyCode` liftCode plcVersion110 succeedingInverseParams
+    `unsafeApplyCode` liftCode plcVersion110 succeedingExpModIntegerInverseParams
 
-succeedingExponentOnePolicy :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
-succeedingExponentOnePolicy =
-  $$(compile [||mkExponentOnePolicy||])
-    `unsafeApplyCode` liftCode plcVersion110 succeedingExponentOneParams
+succeedingExpModIntegerExponentOnePolicy :: CompiledCode (P.BuiltinData -> P.BuiltinUnit)
+succeedingExpModIntegerExponentOnePolicy =
+  $$(compile [||mkExpModIntegerExponentOnePolicy||])
+    `unsafeApplyCode` liftCode plcVersion110 succeedingExpModIntegerExponentOneParams
 
 failingExpModIntegerScriptGroup
   :: ScriptGroup DefaultUni DefaultFun (P.BuiltinData -> P.BuiltinUnit)


### PR DESCRIPTION
This renames some tests from `*ExponentOne*` to `*ExpModIntegerExponentOne*` to make them more consistent with other tests.